### PR TITLE
Fix mobile margin

### DIFF
--- a/components/article/ArticleCard.module.scss
+++ b/components/article/ArticleCard.module.scss
@@ -30,8 +30,9 @@
 }
 
 .articleContainer {
-  word-wrap: anywhere;
   width: 100%;
+  word-wrap: break-word;
+  word-break: break-all;
 }
 
 .articleContainer p {
@@ -59,14 +60,15 @@
 .buttonsContainer {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
   width: 100%;
   margin-top: 8px;
 }
 
-.actionButtonContainer {
-  display: inline-block;
+.actionButton {
+  display: flex;
+  flex-grow: 0;
+  flex-shrink: 1;
+  flex-basis: content;
   margin-right: 12px;
   margin-top: 12px;
 }

--- a/components/article/ArticleCard.module.scss
+++ b/components/article/ArticleCard.module.scss
@@ -31,8 +31,6 @@
 
 .articleContainer {
   width: 100%;
-  word-wrap: break-word;
-  word-break: break-all;
 }
 
 .articleContainer p {
@@ -55,6 +53,10 @@
 // Targets references section
 .articleContainer ol li p {
   margin: 0;
+}
+
+.articleContainer ol li p a {
+  word-wrap: break-word;
 }
 
 .buttonsContainer {

--- a/components/article/ArticleCard.tsx
+++ b/components/article/ArticleCard.tsx
@@ -32,11 +32,9 @@ export const ArticleCard = forwardRef<HTMLDivElement, {
       {hasButtons && (
         <div className={styles.buttonsContainer}>
           {actions.map(action => (
-            <div key={action.label} className={styles.actionButtonContainer}>
-              <Button href={action.url}>
-                {action.label}
-              </Button>
-            </div>
+            <Button key={action.label} href={action.url} className={styles.actionButton}>
+              {action.label}
+            </Button>
           ))}
         </div>
       )}

--- a/components/article/StartPath.tsx
+++ b/components/article/StartPath.tsx
@@ -41,9 +41,7 @@ export const StartPath = (props: {
         const article1Rect = article1.getBoundingClientRect();
         const article2Rect = article2.getBoundingClientRect();
 
-        // 50px added to prevent being cut off by header layout.
-        // TODO header layout should be changed to no longer need this extra 50px
-        const newWidth = Math.floor(article2Rect.right - article1Rect.left + 50);
+        const newWidth = Math.floor(article2Rect.right - article1Rect.left);
         const newHeight = Math.floor((article1Rect.bottom + article1Rect.top) / 2 - titleRect.top);
 
         let didDimensionChange = false;

--- a/components/common/Button.module.scss
+++ b/components/common/Button.module.scss
@@ -27,7 +27,6 @@
   display: inline-flex;
   padding: 0.5em 1em;
   text-decoration: none;
-  white-space: nowrap;
 }
 .container:focus-visible {
   // Disables possible browser default shadow and outline for focus-visible

--- a/components/connectFour/ConnectFour.tsx
+++ b/components/connectFour/ConnectFour.tsx
@@ -12,9 +12,9 @@ import { ConnectFourNNStrategyMultiThread } from "lib/connectFour/connectFourNNS
 import { TerminalValue } from "lib/turnGame/model";
 import { ConnectFourBoard } from "lib/connectFour/connectFourBoard";
 
-// TODO create controlled component connect 4 board whose only purpose is to display the .
+// TODO create controlled component connect 4 board whose only purpose is to display the board.
 // Use the new component in this component.
-// TODO change css styling to match other components
+// TODO change loader styling to something better. Check that it works on small screens.
 export default function ConnectFour() {
   const [controller, setController] = useState<ConnectFourController>();
   const [game, setGame] = useState<ConnectFourBoard>();

--- a/components/nav/NavHeader.module.scss
+++ b/components/nav/NavHeader.module.scss
@@ -6,6 +6,7 @@
   background-color: colors.$surface;
   color: colors.$on-surface;
   display: flex;
+  flex-wrap: wrap;
   list-style-type: none;
   margin: 0;
   padding: 10px;

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -7,7 +7,6 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  overflow: visible;
   padding: 75px 0;
   position: relative;
   min-height: 400px;
@@ -115,7 +114,9 @@
 }
 
 .articleRight {
-  justify-content: flex-end;
+  @include breakpoints.breakpoint-up(sm) {
+    justify-content: flex-end;
+  }
 }
 
 .articleCard {

--- a/pages/values.module.scss
+++ b/pages/values.module.scss
@@ -62,6 +62,8 @@
 .articleContainer {
   flex-basis: breakpoints.$md;
   margin: 0 20px;
+  word-wrap: break-word;
+  word-break: break-all;
 
   @include breakpoints.breakpoint-up(sm) {
     margin: 0 40px;

--- a/pages/values.module.scss
+++ b/pages/values.module.scss
@@ -62,8 +62,6 @@
 .articleContainer {
   flex-basis: breakpoints.$md;
   margin: 0 20px;
-  word-wrap: break-word;
-  word-break: break-all;
 
   @include breakpoints.breakpoint-up(sm) {
     margin: 0 40px;
@@ -79,7 +77,7 @@
   margin-top: 0;
 }
 
-.articleContainer h2 {
+.articleContainer h1, .articleContainer h2, .articleContainer h3, .articleContainer h4 {
   margin: 1em 0 0.5em;
 }
 
@@ -93,6 +91,10 @@
 // Targets references section
 .articleContainer ol li p {
   margin: 0;
+}
+
+.articleContainer ol li p a {
+  word-wrap: break-word;
 }
 
 .articleSideContainer {

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -16,10 +16,13 @@ body {
   color: colors.$on-surface;
 
   background-color: colors.$surface;
-  min-width: 300px;
   margin: 0;
   padding: 0;
 }
+
+html, body {
+  overflow-x: scroll;
+} 
 
 :root {
   --primary-color: #{colors.$theme-primary-color};

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -16,6 +16,7 @@ body {
   color: colors.$on-surface;
 
   background-color: colors.$surface;
+  min-width: 300px;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Fix width overflow issues on small screens. Layout is still not as intended when width is small and content overflows, but all content is now reachable by scrolling.

See
- https://stackoverflow.com/questions/30358630/html-body-not-filling-complete-width-on-mobile-devices
- https://stackoverflow.com/questions/14270084/overflow-xhidden-doesnt-prevent-content-from-overflowing-in-mobile-browsers/14271049#14271049